### PR TITLE
[Minor] - forEach doesn't actually break/ return

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -58,20 +58,20 @@ class ExtractTextPlugin {
   mergeNonInitialChunks(chunk, intoChunk, checkedChunks) {
     if (!intoChunk) {
       checkedChunks = [];
-      chunk.chunks.forEach((c) => {
-        if (isInitialOrHasNoParents(c)) return;
-        this.mergeNonInitialChunks(c, chunk, checkedChunks);
-      }, this);
+      for (const c of chunk.chunks) {
+        if (isInitialOrHasNoParents(c)) break;
+        mergeNonInitialChunks(c, chunk, checkedChunks);
+      }
     } else if (checkedChunks.indexOf(chunk) < 0) {
       checkedChunks.push(chunk);
       chunk.forEachModule((module) => {
         intoChunk.addModule(module);
         module.addChunk(intoChunk);
       });
-      chunk.chunks.forEach((c) => {
-        if (isInitialOrHasNoParents(c)) return;
-        this.mergeNonInitialChunks(c, intoChunk, checkedChunks);
-      }, this);
+      for (const c of chunk.chunks) {
+        if (isInitialOrHasNoParents(c)) break;
+        mergeNonInitialChunks(c, intoChunk, checkedChunks);
+      }
     }
   }
 


### PR DESCRIPTION
Feature
Changed the forEach to a for..of loop to allow it to exit early.

I am open to suggestions/ improvements, since I did delete the explicit this context.

<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
DONE.

2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
DONE.

3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
DONE.
-->
